### PR TITLE
Corrects issue where ACAS host names containing "\" break output text files

### DIFF
--- a/Model/OpenXmlReportCreator.cs
+++ b/Model/OpenXmlReportCreator.cs
@@ -2329,6 +2329,7 @@ namespace Vulnerator.Model
                 Regex regex = new Regex(regexPattern);
                 cellValue = regex.Replace(cellValue, "\r\n");
                 assetName = assetName.Replace("\r\n", "__");
+                assetName = assetName.Replace("\\", "-");
                 string outputPath = Environment.GetFolderPath(Environment.SpecialFolder.Desktop) + @"\AcasScanOutput_TextFiles";
                 string outputTextFile = string.Empty;
 


### PR DESCRIPTION
## Proposed Changes
_Please provide a brief, bulletized synopsis of the changes introduced in this pull request_
- Replaces "\\" with "-" when creating the ACAS Output text file names

## Resolved Issues
_Please list any issues resolved in this pull request_
- #77 