### PR TITLE
Updates what cells are checked for large lengths

### DIFF
--- a/Model/FprReader.cs
+++ b/Model/FprReader.cs
@@ -321,26 +321,6 @@ namespace Vulnerator.Model
             }
         }
 
-        private void CreateAddAssetCommand(string systemName)
-        {
-            try
-            {
-                using (SQLiteCommand sqliteCommand = FindingsDatabaseActions.sqliteConnection.CreateCommand())
-                {
-                    sqliteCommand.Parameters.Add(new SQLiteParameter("AssetIdToReport", file));
-                    sqliteCommand.Parameters.Add(new SQLiteParameter("GroupName", systemName));
-                    sqliteCommand.CommandText = "INSERT INTO Assets (AssetIndex, AssetIdToReport, HostName, GroupIndex) " +
-                        "VALUES(NULL, @AssetIdToReport, @AssetIdToReport, (SELECT GroupIndex FROM Groups WHERE GroupName = @GroupName));";
-                    sqliteCommand.ExecuteNonQuery();
-                }
-            }
-            catch (Exception exception)
-            {
-                log.Error("Unable to insert Asset into Assets.");
-                throw exception;
-            }
-        }
-
         private void CreateAddSourceCommand()
         {
             try

--- a/Model/FprReader.cs
+++ b/Model/FprReader.cs
@@ -321,6 +321,26 @@ namespace Vulnerator.Model
             }
         }
 
+        private void CreateAddAssetCommand(string systemName)
+        {
+            try
+            {
+                using (SQLiteCommand sqliteCommand = FindingsDatabaseActions.sqliteConnection.CreateCommand())
+                {
+                    sqliteCommand.Parameters.Add(new SQLiteParameter("AssetIdToReport", file));
+                    sqliteCommand.Parameters.Add(new SQLiteParameter("GroupName", systemName));
+                    sqliteCommand.CommandText = "INSERT INTO Assets (AssetIndex, AssetIdToReport, HostName, GroupIndex) " +
+                        "VALUES(NULL, @AssetIdToReport, @AssetIdToReport, (SELECT GroupIndex FROM Groups WHERE GroupName = @GroupName));";
+                    sqliteCommand.ExecuteNonQuery();
+                }
+            }
+            catch (Exception exception)
+            {
+                log.Error("Unable to insert Asset into Assets.");
+                throw exception;
+            }
+        }
+
         private void CreateAddSourceCommand()
         {
             try


### PR DESCRIPTION
## Proposed Changes
_Please provide a brief, bulletized synopsis of the changes introduced in this pull request_
- `LargeCellValueHandler()` is now utilized to check against additional fields ("Comments", "Finding Details", etc.)
- The max threshold for a string that will be passed to `WriteCellValues()` is lowered from 32767 to 32000

## Resolved Issues
_Please list any issues resolved in this pull request_
- #84 
- #7 